### PR TITLE
Drupal 9 compatibility

### DIFF
--- a/elasticsearch_helper_aws.info.yml
+++ b/elasticsearch_helper_aws.info.yml
@@ -1,6 +1,7 @@
 name: AWS Elasticsearch Service for Elasticsearch Helper
 description: Connect to the AWS hosted Elasticsearch service with Elasticsearch Helper
 type: module
+core_version_requirement: ^8 || ^9
 core: 8.x
 package: ElasticSearch Helper
 configure: elasticsearch_helper_aws.settings_form


### PR DESCRIPTION
This PR adds Drupal 9 readiness for elasticsearch_helper_views module.

Note:
Marking `core_version_requirement: ^8 || ^9 `as there is no deprecations introduced after 8.0.x

Checked with [Upgrade status](https://www.drupal.org/project/upgrade_status)