### PR TITLE
Removed unneccessary form alter. Local task definition is enough.

### DIFF
--- a/elasticsearch_helper_aws.module
+++ b/elasticsearch_helper_aws.module
@@ -2,14 +2,13 @@
 
 /**
  * @file
+ * Hook implementations for elasticsearch_helper_aws.
  */
 
-use Drupal\Core\Url;
 use Elasticsearch\ClientBuilder;
 use Aws\Credentials\CredentialProvider;
 use Aws\Credentials\Credentials;
 use Aws\ElasticsearchService\ElasticsearchPhpHandler;
-use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_elasticsearch_helper_client_builder_alter().
@@ -29,15 +28,4 @@ function elasticsearch_helper_aws_elasticsearch_helper_client_builder_alter(Clie
 
     $clientBuilder->setHandler($handler);
   }
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- */
-function elasticsearch_helper_aws_form_elasticsearch_helper_settings_form_alter(array &$form, FormStateInterface $form_state) {
-  $form['aws_message'] = [
-    '#type' => 'link',
-    '#url' => Url::fromRoute('elasticsearch_helper_aws.settings_form'),
-    '#title' => t('AWS Settings for Elasticsearch '),
-  ];
 }


### PR DESCRIPTION
This PR removes unneccessary form alter. Local task definition is enough (i.e. AWS Elasticsearch Settings tab in Elasticsearch Helper settings page).